### PR TITLE
Disable Unused Exchangers

### DIFF
--- a/config/Exchangers.cfg
+++ b/config/Exchangers.cfg
@@ -4,13 +4,13 @@ exchangers {
 
     modules {
         # If true, enables Ender IO-based exchangers (Requires Ender IO to be installed).
-        B:enderIOModule=true
+        B:enderIOModule=false
 
         # If true, enables Immersive Engineering-based exchangers (Requires Immersive Engineering to be installed).
-        B:immersiveEngineeringModule=true
+        B:immersiveEngineeringModule=false
 
         # If true, enables Mekanism-based exchangers (Requires Mekanism to be installed).
-        B:mekanismModule=true
+        B:mekanismModule=false
 
         # If true, enables special exchangers (e.g. Tuberous Exchanger).
         B:specialModule=true


### PR DESCRIPTION
Disabled unused exchangers from mods not in the pack. They still show up in JEI with no recipes even without the mod otherwise.