### PR TITLE
revert ordict ownership priorty ordering

### DIFF
--- a/config/unidict/UniDict.cfg
+++ b/config/unidict/UniDict.cfg
@@ -228,7 +228,6 @@ resources {
     #  [default: [minecraft], [thermalfoundation], [substratum], [ic2], [mekanism], [immersiveengineering], [techreborn]]
     S:ownerOfEveryThing <
         minecraft
-        alchemistry
         thermalfoundation
         nuclearcraft
         substratum
@@ -238,6 +237,7 @@ resources {
         techreborn
         appliedenergistics2
         refinedstorage
+        alchemistry
         tconstruct
      >
 


### PR DESCRIPTION
Moving alchemistry near the top of the list breaks a number of reciepes that
prior took ingots generated via the combiner and now require mod specific
versions to be created in different manners.

Examples include:
- nuclearcraft Li, B and Mg used to make alloys
- thermalfoundation Pt, Ag, Pb... etc.

## Tough Alloy example:

### After changes in v2.30.0+
This is the only recipe available and this type of Li can't be created in a combiner; it makes alchemistry ingots. 
![image](https://user-images.githubusercontent.com/397853/168130517-9ddab326-052e-4e54-864f-27a2e7090b29.png)

### With this change
This is an additional variation:
![image](https://user-images.githubusercontent.com/397853/168130870-946f1ae7-2bed-40b5-9967-6eebda665b72.png)

The combiner now creates nuclearcraft ingots as it did before:
![image](https://user-images.githubusercontent.com/397853/168130909-70040aaa-ef03-4b2e-9b0b-66cf320e7987.png)
