### PR TITLE
Fix spelling and consistency

### DIFF
--- a/scripts/DraconicEvolution/recipes.zs
+++ b/scripts/DraconicEvolution/recipes.zs
@@ -25,13 +25,13 @@ var dracNugget as IItemStack = <draconicevolution:nugget>;
 var dimShard as IItemStack = <rftools:dimensional_shard>;
 
 disable(<draconicevolution:draconium_ore>);
-<draconicevolution:draconium_ore>.addTooltip(format.red("-> Draconium needs to be craftet."));
+<draconicevolution:draconium_ore>.addTooltip(format.red("-> Draconium needs to be crafted."));
 
 disable(<draconicevolution:draconium_ore:1>);
-<draconicevolution:draconium_ore:1>.addTooltip(format.red("-> Draconium needs to be craftet."));
+<draconicevolution:draconium_ore:1>.addTooltip(format.red("-> Draconium needs to be crafted."));
 
 disable(<draconicevolution:draconium_ore:2>);
-<draconicevolution:draconium_ore:2>.addTooltip(format.red("-> Draconium needs to be craftet."));
+<draconicevolution:draconium_ore:2>.addTooltip(format.red("-> Draconium needs to be crafted."));
 
 var mapRecipe as IIngredient[][][][IItemStack] = {
     <draconicevolution:draconium_ingot> : [

--- a/scripts/GameStages/alchemistry.zs
+++ b/scripts/GameStages/alchemistry.zs
@@ -22,7 +22,7 @@ import mods.recipestages.Recipes as stageRecipes;
 
 var stage as string = "netherstar";
 
-<alchemistry:fusion_controller>.addTooltip("Unlocked by completing nether star quest");
+<alchemistry:fusion_controller>.addTooltip("Unlocked by completing the nether star quest");
 
 var mapRecipe as IIngredient[][][][IItemStack] = {
     <alchemistry:fusion_controller>: [

--- a/scripts/GameStages/tconstruct.zs
+++ b/scripts/GameStages/tconstruct.zs
@@ -24,7 +24,7 @@ var stage as string = "tinkers";
 
 var searedBrick as IItemStack = <tconstruct:materials>;
 
-<tconstruct:smeltery_controller>.addTooltip("Unlocked in Chapter 3");
+<tconstruct:smeltery_controller>.addTooltip("Unlocked in chapter 3");
 
 var mapRecipe as IIngredient[][][][IItemStack] = {
     <tconstruct:smeltery_controller> : [


### PR DESCRIPTION
craftet => crafted (in the Draconium Ore tooltips)
completing nether star quest => completing the nether star quest (in the Fusion Controller tooltip)
Chapter 3 => chapter 3 (like the rest of the tooltips)

Honestly kinda surprised no one did this earlier, some of them are ~3 years old.