### PR TITLE
Chapter 6 fixes

### DIFF
--- a/config/ftbquests/normal/chapters/3d666205/2ea29e73.snbt
+++ b/config/ftbquests/normal/chapters/3d666205/2ea29e73.snbt
@@ -1,7 +1,7 @@
 {
 	x: 6.0d,
 	y: -9.0d,
-	description: "Create 4 awakened draconic blocks",
+	description: "Create 4 awakened draconium blocks",
 	dependencies: [
 		"5ce99244"
 	],

--- a/config/ftbquests/normal/chapters/3d666205/5ce99244.snbt
+++ b/config/ftbquests/normal/chapters/3d666205/5ce99244.snbt
@@ -2,7 +2,7 @@
 	title: "Wyvern Fusion Crafting",
 	x: 4.0d,
 	y: -9.0d,
-	description: "Create 7 wyvern fusion crafting injectors",
+	description: "Create 9 wyvern fusion crafting injectors",
 	dependencies: [
 		"fa60684e",
 		"03733258"
@@ -13,7 +13,7 @@
 		items: [{
 			item: "draconicevolution:crafting_injector 1 1"
 		}],
-		count: 7L
+		count: 9L
 	}],
 	rewards: [{
 		uid: "5616bba8",

--- a/config/ftbquests/normal/chapters/3d666205/6a2078cd.snbt
+++ b/config/ftbquests/normal/chapters/3d666205/6a2078cd.snbt
@@ -5,7 +5,7 @@
 	shape: "circle",
 	description: "Mine up 32 dimensional shards",
 	text: [
-		"The ore can be found underground on the same level of diamond in RF dimensions"
+		"The ore can be found underground on the same Y-level as diamonds in RF dimensions"
 	],
 	dependencies: [
 		"a291ef20"

--- a/config/ftbquests/normal/chapters/3d666205/735f0b0c.snbt
+++ b/config/ftbquests/normal/chapters/3d666205/735f0b0c.snbt
@@ -4,7 +4,7 @@
 	y: -9.0d,
 	description: "Craft 8 draconium ingots",
 	text: [
-		"Draconium dust is gotten from the ender dragon and it's data model"
+		"Draconium dust can be obtained from the ender dragon and its data model"
 	],
 	dependencies: [
 		"6a2078cd",


### PR DESCRIPTION
Fi​x​e​s a pa​rt of https://github.com/SmashingMods/antimatter-chemistry/issues/389#issuecomment-2187402373 and other smaller stuff I've noticed.
Other things to consider related to chapter 6 (aka the reason why this is a draft PR):
- the ender star can be obtained from killing the wither, but you still have to get the chemicals from the quest line to unlock fusion and progress further
- kinda weird how just the lutetium is separated into 2 quests, where the other "Collect a stack of x motes" just have the required items written in their description
- description of the fusion multiblock could be slightly improved

also fyi, I edited the files directly instead of going through `/ftbquests editing_mode`, and in true developer fashion, I did not test if anything works